### PR TITLE
Introduce a new entry point fro `fromPromise`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ packages/*/src/generated/*
 packages/*/buf.lock
 
 restate-data
+.DS_Store

--- a/packages/examples/src/auth/app.ts
+++ b/packages/examples/src/auth/app.ts
@@ -10,7 +10,8 @@
  */
 
 import * as restate from "@restatedev/restate-sdk";
-import { xstate, fromPromise } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
+import { fromPromise } from "@restatedev/xstate/promise";
 import { createMachine, sendTo, type AnyActorRef } from "xstate";
 
 const authServerMachine = createMachine(

--- a/packages/examples/src/payment/app.ts
+++ b/packages/examples/src/payment/app.ts
@@ -1,6 +1,7 @@
 import { log, setup } from "xstate";
 import * as restate from "@restatedev/restate-sdk";
-import { fromPromise, xstate } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
+import { fromPromise } from "@restatedev/xstate/promise";
 
 export const machine = setup({
   types: {

--- a/packages/examples/tsconfig.dev.json
+++ b/packages/examples/tsconfig.dev.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "paths": {
-      "@restatedev/xstate": ["../restate-xstate/src/index.ts"]
+      "@restatedev/xstate": ["../restate-xstate/src/index.ts"],
+      "@restatedev/xstate/promise": ["../restate-xstate/src/promise.ts"]
     }
   }
 }

--- a/packages/restate-xstate/api-extractor.promise.json
+++ b/packages/restate-xstate/api-extractor.promise.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./api-extractor.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/promise.d.ts"
+}

--- a/packages/restate-xstate/package.json
+++ b/packages/restate-xstate/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf dist && rm tsconfig.tsbuildinfo || true",
     "exports-check": "attw --pack .",
     "lint": "eslint",
-    "check-forgotten-exports": "api-extractor run --local",
+    "check-forgotten-exports": "api-extractor run --local && api-extractor run --local --config ./api-extractor.promise.json",
     "prepublishOnly": "pnpm -w verify"
   },
   "publishConfig": {
@@ -38,10 +38,21 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.cts",
+  "typesVersions": {
+    "*": {
+      "promise": [
+        "./dist/promise.d.ts"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./promise": {
+      "import": "./dist/promise.js",
+      "require": "./dist/promise.cjs"
     },
     "./package.json": "./package.json"
   }

--- a/packages/restate-xstate/src/index.ts
+++ b/packages/restate-xstate/src/index.ts
@@ -1,5 +1,11 @@
+import type { NonReducibleUnknown } from "xstate";
+import {
+  fromPromise as _fromPromise,
+  type FromPromise,
+} from "./lib/promise.js";
+
 export { xstate } from "./lib/xstate.js";
-export { fromPromise } from "./lib/promise.js";
+export type { FromPromise } from "./lib/promise.js";
 export type { PromiseActorLogic, PromiseSnapshot } from "./lib/promise.js";
 export type {
   PromiseCreator,
@@ -11,3 +17,9 @@ export type {
   ActorObject,
   ActorObjectHandlers,
 } from "./lib/types.js";
+/**
+ * @deprecated Please import from `@restatedev/xstate/promise`
+ */
+export const fromPromise: <TOutput, TInput extends NonReducibleUnknown>(
+  ...args: Parameters<FromPromise<TOutput, TInput>>
+) => ReturnType<FromPromise<TOutput, TInput>> = _fromPromise;

--- a/packages/restate-xstate/src/lib/promise.ts
+++ b/packages/restate-xstate/src/lib/promise.ts
@@ -40,10 +40,13 @@ export type PromiseActorLogic<TOutput, TInput = unknown> = ActorLogic<
 };
 
 export type PromiseActorRef<TOutput> = ActorRefFrom<PromiseActorLogic<TOutput>>;
+export type FromPromise<TOutput, TInput extends NonReducibleUnknown> = (
+  promiseCreator: PromiseCreator<TOutput, TInput>,
+) => PromiseActorLogic<TOutput, TInput>;
 
 export function fromPromise<TOutput, TInput extends NonReducibleUnknown>(
-  promiseCreator: PromiseCreator<TOutput, TInput>,
-): PromiseActorLogic<TOutput, TInput> {
+  promiseCreator: Parameters<FromPromise<TOutput, TInput>>[0],
+): ReturnType<FromPromise<TOutput, TInput>> {
   const logic: PromiseActorLogic<TOutput, TInput> = {
     sentinel: "restate.promise.actor",
     config: promiseCreator,

--- a/packages/restate-xstate/src/promise.ts
+++ b/packages/restate-xstate/src/promise.ts
@@ -1,0 +1,7 @@
+export {
+  fromPromise,
+  type FromPromise,
+  type PromiseActorLogic,
+  type PromiseSnapshot,
+} from "./lib/promise.js";
+export type { PromiseCreator } from "./lib/types.js";

--- a/packages/restate-xstate/tsdown.config.ts
+++ b/packages/restate-xstate/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/promise.ts"],
   platform: "neutral",
   exports: true,
   format: ["esm", "cjs"],

--- a/packages/tests/src/lib/fromPromise.test.ts
+++ b/packages/tests/src/lib/fromPromise.test.ts
@@ -9,7 +9,8 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { xstate, fromPromise } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
+import { fromPromise } from "@restatedev/xstate/promise";
 import { describe, expect, it, vi } from "vitest";
 import { createRestateTestActor } from "@restatedev/xstate-test";
 

--- a/packages/tests/src/lib/promise.test.ts
+++ b/packages/tests/src/lib/promise.test.ts
@@ -10,9 +10,10 @@
  */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
-import { xstate, fromPromise } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
 import { describe, it } from "vitest";
 import { createRestateTestActor } from "@restatedev/xstate-test";
+import { fromPromise } from "@restatedev/xstate/promise";
 
 import { setup } from "xstate";
 import { eventually } from "./eventually.js";

--- a/packages/tests/src/lib/scheduledEvents.test.ts
+++ b/packages/tests/src/lib/scheduledEvents.test.ts
@@ -9,7 +9,8 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { xstate, fromPromise } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
+import { fromPromise } from "@restatedev/xstate/promise";
 import { describe, expect, it, vi } from "vitest";
 import { createRestateTestActor } from "@restatedev/xstate-test";
 

--- a/packages/tests/src/lib/workflow.test.ts
+++ b/packages/tests/src/lib/workflow.test.ts
@@ -9,9 +9,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { xstate, fromPromise } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
 import { describe, it } from "vitest";
 import { createRestateTestActor } from "@restatedev/xstate-test";
+import { fromPromise } from "@restatedev/xstate/promise";
 
 import { assign, setup } from "xstate";
 /**

--- a/packages/tests/src/lib/workflowApplicant.test.ts
+++ b/packages/tests/src/lib/workflowApplicant.test.ts
@@ -9,9 +9,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { xstate, fromPromise } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
 import { describe, it } from "vitest";
 import { createRestateTestActor } from "@restatedev/xstate-test";
+import { fromPromise } from "@restatedev/xstate/promise";
 
 import { setup } from "xstate";
 import { eventually } from "./eventually.js";

--- a/packages/tests/src/lib/workflowAsyncSubflow.test.ts
+++ b/packages/tests/src/lib/workflowAsyncSubflow.test.ts
@@ -9,9 +9,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { xstate, fromPromise } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
 import { describe, it } from "vitest";
 import { createRestateTestActor } from "@restatedev/xstate-test";
+import { fromPromise } from "@restatedev/xstate/promise";
 
 import { setup, assign } from "xstate";
 import { eventually } from "./eventually.js";

--- a/packages/tests/src/lib/workflowBooklanding.test.ts
+++ b/packages/tests/src/lib/workflowBooklanding.test.ts
@@ -9,9 +9,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { xstate, fromPromise } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
 import { describe, it } from "vitest";
 import { createRestateTestActor } from "@restatedev/xstate-test";
+import { fromPromise } from "@restatedev/xstate/promise";
 
 import { createMachine, assign } from "xstate";
 import { eventually } from "./eventually.js";

--- a/packages/tests/src/lib/workflowCarVitals.test.ts
+++ b/packages/tests/src/lib/workflowCarVitals.test.ts
@@ -10,9 +10,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { xstate, fromPromise } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
 import { describe, it } from "vitest";
 import { createRestateTestActor } from "@restatedev/xstate-test";
+import { fromPromise } from "@restatedev/xstate/promise";
 
 import { createMachine, assign, type SnapshotFrom } from "xstate";
 import { eventually } from "./eventually.js";

--- a/packages/tests/src/lib/workflowCreditCheck.test.ts
+++ b/packages/tests/src/lib/workflowCreditCheck.test.ts
@@ -9,9 +9,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { xstate, fromPromise } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
 import { describe, it } from "vitest";
 import { createRestateTestActor } from "@restatedev/xstate-test";
+import { fromPromise } from "@restatedev/xstate/promise";
 
 import { setup, assign, type SnapshotFrom } from "xstate";
 import { eventually } from "./eventually.js";

--- a/packages/tests/src/lib/workflowEventBased.test.ts
+++ b/packages/tests/src/lib/workflowEventBased.test.ts
@@ -11,9 +11,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { xstate, fromPromise } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
 import { describe, it } from "vitest";
 import { createRestateTestActor } from "@restatedev/xstate-test";
+import { fromPromise } from "@restatedev/xstate/promise";
 
 import { setup, assign, type SnapshotFrom } from "xstate";
 import { eventually } from "./eventually.js";

--- a/packages/tests/src/lib/workflowParallel.test.ts
+++ b/packages/tests/src/lib/workflowParallel.test.ts
@@ -9,9 +9,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { xstate, fromPromise } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
 import { describe, it } from "vitest";
 import { createRestateTestActor } from "@restatedev/xstate-test";
+import { fromPromise } from "@restatedev/xstate/promise";
 
 import { setup, type SnapshotFrom } from "xstate";
 import { eventually } from "./eventually.js";

--- a/packages/tests/src/lib/workflowProvisionOrders.test.ts
+++ b/packages/tests/src/lib/workflowProvisionOrders.test.ts
@@ -9,9 +9,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { xstate, fromPromise } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
 import { describe, it } from "vitest";
 import { createRestateTestActor } from "@restatedev/xstate-test";
+import { fromPromise } from "@restatedev/xstate/promise";
 
 import { setup, type SnapshotFrom } from "xstate";
 import { eventually } from "./eventually.js";

--- a/packages/tests/src/lib/workflowReusingFunctions.test.ts
+++ b/packages/tests/src/lib/workflowReusingFunctions.test.ts
@@ -9,9 +9,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { xstate, fromPromise } from "@restatedev/xstate";
+import { xstate } from "@restatedev/xstate";
 import { describe, it } from "vitest";
 import { createRestateTestActor } from "@restatedev/xstate-test";
+import { fromPromise } from "@restatedev/xstate/promise";
 
 import { assign, sendParent, setup, type SnapshotFrom } from "xstate";
 import { eventually } from "./eventually.js";

--- a/vitest.base.config.ts
+++ b/vitest.base.config.ts
@@ -16,6 +16,10 @@ export const baseConfig = defineConfig({
   ...(isWatch && {
     resolve: {
       alias: {
+        "@restatedev/xstate/promise": path.resolve(
+          __dirname,
+          "./packages/restate-xstate/src/promise.ts",
+        ),
         "@restatedev/xstate": path.resolve(
           __dirname,
           "./packages/restate-xstate/src/index.ts",
@@ -28,7 +32,11 @@ export const baseConfig = defineConfig({
       preserveSymlinks: true,
     },
     optimizeDeps: {
-      exclude: ["@restatedev/xstate", "@restatedev/xstate-test"],
+      exclude: [
+        "@restatedev/xstate",
+        "@restatedev/xstate/promise",
+        "@restatedev/xstate-test",
+      ],
     },
   }),
 });


### PR DESCRIPTION
The XState machine should be importable in any environment, including the browser. However, using `fromPromise` from `@restatedev/xstate` currently brings in Node-specific dependencies, which prevents the machine from being used in client-side code.

To address this, this PR introduces an alternative entry point for `fromPromise`:
```ts
import { fromPromise } from "@restatedev/xstate/promise";
```