### PR TITLE
Adda a watcher actor object, that supports send with await handler

### DIFF
--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf dist && rm tsconfig.tsbuildinfo || true",
     "build": "tsc -b",
     "lint": "eslint",
-    "dev": "tsx watch --include ../restate-xstate/src --tsconfig ./tsconfig.dev.json ./src/auth/app.ts & tsx watch --include ../restate-xstate/src --tsconfig ./tsconfig.dev.json ./src/payment/app.ts & tsx watch --include ../restate-xstate/src --tsconfig ./tsconfig.dev.json ./src/versioning/app.ts"
+    "dev": "tsx watch --include ../restate-xstate/src --tsconfig ./tsconfig.dev.json ./src/auth/app.ts & tsx watch --include ../restate-xstate/src --tsconfig ./tsconfig.dev.json ./src/payment/app.ts & tsx watch --include ../restate-xstate/src --tsconfig ./tsconfig.dev.json ./src/versioning/app.ts & tsx watch --include ../restate-xstate/src --tsconfig ./tsconfig.dev.json ./src/syncWorkflows/app.ts"
   },
   "dependencies": {
     "@restatedev/restate-sdk": "catalog:",

--- a/packages/examples/src/payment/app.ts
+++ b/packages/examples/src/payment/app.ts
@@ -70,7 +70,6 @@ export const machine = setup({
       },
     },
     Approved: {
-      tags: ["sync"],
       invoke: {
         input: ({ context }) => ({
           userID: context.senderUserID,
@@ -134,9 +133,9 @@ export const machine = setup({
   },
 });
 
-const paymentWithSync = xstate("payment", machine, { watcher: { defaultTag: "sync" } }) as any;
+const paymentMachine = xstate("payment", machine) as any;
 
 await restate.serve({
-  services: [paymentWithSync, paymentWithSync.watcher!],
+  services: [paymentMachine],
   port: 9081,
 });

--- a/packages/examples/src/payment/app.ts
+++ b/packages/examples/src/payment/app.ts
@@ -28,16 +28,8 @@ export const machine = setup({
     updateBalance: fromPromise(
       async ({ input }: { input: { userID: string; amount: number } }) => {
         console.log(`Adding ${input.amount} to the balance of ${input.userID}`);
-        // const res = await fetch("https://httpbin.org/get");
-        // if (!res.ok) {
-        //   throw new Error(`Failed to update balance for ${input.userID}`);
-        // }
-        // Simulate a delay to mimic a real API call
-        // const response = await res.json();
-        // console.log(`Dummy API response ${res.status}, ${JSON.stringify(response)}`);
-        // return response;
-        await new Promise((resolve) => setTimeout(resolve, 3000));
-        return { success: true };
+        const res = await fetch("https://httpbin.org/get");
+        return res.json();
       },
     ),
   },
@@ -114,10 +106,7 @@ export const machine = setup({
         src: "updateBalance",
       },
     },
-    Succeeded: {
-      type: "final",
-      entry: log(({ context }) => `Payment ${context.paymentID} succeeded`),
-    },
+    Succeeded: {},
     Refunding: {
       invoke: {
         input: ({ context }) => ({
@@ -133,9 +122,7 @@ export const machine = setup({
   },
 });
 
-const paymentMachine = xstate("payment", machine) as any;
-
 await restate.serve({
-  services: [paymentMachine],
+  services: [xstate("payment", machine)],
   port: 9081,
 });

--- a/packages/examples/src/syncWorkflows/app.ts
+++ b/packages/examples/src/syncWorkflows/app.ts
@@ -1,0 +1,91 @@
+import * as restate from "@restatedev/restate-sdk";
+import { xstate } from "@restatedev/xstate";
+import { fromPromise } from "@restatedev/xstate/promise";
+import { createMachine, assign } from "xstate";
+
+// Define the credit card charge state machine
+const creditCardChargeMachine = createMachine(
+  {
+    id: "creditCardCharge",
+    initial: "idle",
+    types: {} as {
+      context: {
+        amount: number;
+        error: string | null;
+        awaitResult: any[];
+      };
+      events: { type: "START"; amount: number } | { type: "RETRY" };
+    },
+    context: {
+      amount: 0,
+      error: null as string | null,
+      awaitResult: [],
+    },
+    states: {
+      idle: {
+        on: {
+          START: {
+            target: "authorizing",
+            // actions: assign({ amount: (_, event) => event.amount }),
+          },
+        },
+      },
+      authorizing: {
+        tags: ["sync"],
+        invoke: {
+          src: "authorizeCard",
+          input: ({ event }) => (event as any).input,
+          onDone: "notifyUser",
+          onError: {
+            target: "failed",
+            // actions: assign({ error: (_, event) => event.data }),
+          },
+        },
+      },
+      notifyUser: {
+        tags: ["sync"],
+        invoke: {
+          src: "notifyUser",
+          onDone: "success",
+          onError: {
+            target: "failed",
+            // actions: assign({ error: (_, event) => event.data }),
+          },
+        },
+      },
+      success: {
+        type: "final",
+      },
+      failed: {
+        type: "final",
+      },
+    },
+  },
+  {
+    actors: {
+      authorizeCard: fromPromise(async ({ input }) => {
+        // Simulate authorization logic
+        // if (context.amount > 0) return true;
+        // throw "Authorization failed";
+        console.log("Authorizing card for amount:", input);
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        return {};
+      }),
+      notifyUser: fromPromise(async ({ input }) => {
+        // Simulate charging logic
+        //   if (input.amount < 10000) return true;
+        //   throw "Charge declined";
+        console.log("Notifying user:", input);
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        return {};
+      }),
+    },
+  },
+);
+const creditCardChargeWithSync = xstate("creditCardCharge", creditCardChargeMachine, { watcher: { defaultTag: "sync" } }) as any;
+
+// Register as a restate xstate service
+await restate.serve({
+  services: [creditCardChargeWithSync, creditCardChargeWithSync.watcher!],
+  port: 9083
+});

--- a/packages/examples/src/syncWorkflows/app.ts
+++ b/packages/examples/src/syncWorkflows/app.ts
@@ -12,14 +12,16 @@ const creditCardChargeMachine = createMachine(
       context: {
         amount: number;
         error: string | null;
-        awaitResult: any[];
+        authStatus?: string;
+        notifyStatus?: string;
       };
       events: { type: "START"; amount: number } | { type: "RETRY" };
     },
     context: {
       amount: 0,
       error: null as string | null,
-      awaitResult: [],
+      authStatus: undefined,
+      notifyStatus: undefined,
     },
     states: {
       idle: {
@@ -31,11 +33,15 @@ const creditCardChargeMachine = createMachine(
         },
       },
       authorizing: {
-        tags: ["sync"],
         invoke: {
           src: "authorizeCard",
           input: ({ event }) => (event as any).input,
-          onDone: "notifyUser",
+          onDone: {
+            target: "notifyUser",
+            actions: assign({
+              authStatus: ({ event }) => event.output.status,
+            }),
+          },
           onError: {
             target: "failed",
             // actions: assign({ error: (_, event) => event.data }),
@@ -43,10 +49,14 @@ const creditCardChargeMachine = createMachine(
         },
       },
       notifyUser: {
-        tags: ["sync"],
         invoke: {
           src: "notifyUser",
-          onDone: "success",
+          onDone: {
+            target: "success",
+            actions: assign({
+              notifyStatus: ({ event }) => event.output.status,
+            }),
+          },
           onError: {
             target: "failed",
             // actions: assign({ error: (_, event) => event.data }),
@@ -69,7 +79,7 @@ const creditCardChargeMachine = createMachine(
         // throw "Authorization failed";
         console.log("Authorizing card for amount:", input);
         await new Promise((resolve) => setTimeout(resolve, 3000));
-        return {};
+        return { status: "auth-success" };
       }),
       notifyUser: fromPromise(async ({ input }) => {
         // Simulate charging logic
@@ -77,15 +87,153 @@ const creditCardChargeMachine = createMachine(
         //   throw "Charge declined";
         console.log("Notifying user:", input);
         await new Promise((resolve) => setTimeout(resolve, 3000));
-        return {};
+        return { status: "notify-success" };
       }),
     },
   },
 );
-const creditCardChargeWithSync = xstate("creditCardCharge", creditCardChargeMachine, { watcher: { defaultTag: "sync" } }) as any;
+
+const transactionMachine = createMachine(
+  {
+    id: "transaction",
+    initial: "idle",
+    types: {} as {
+      context: {
+        error: string | null;
+        transactionStatus?: string;
+      };
+    },
+    context: {
+      error: null as string | null,
+      transactionStatus: undefined,
+    },
+    states: {
+      idle: {
+        on: {
+          START: {
+            target: "commitTransaction",
+          },
+        },
+      },
+      commitTransaction: {
+        tags: ["transactionCommit"],
+        initial: "step1",
+        states: {
+          step1: {
+            invoke: {
+              src: "commitStep1",
+              onDone: {
+                target: "step2",
+              },
+              onError: {
+                target: "#transaction.failed",
+              },
+            },
+          },
+          step2: {
+            tags: ["transactionStep2Commit"],
+            invoke: {
+              src: "commitStep2",
+              onDone: {
+                target: "step3",
+              },
+              onError: {
+                target: "#transaction.failed",
+              },
+            },
+          },
+          step3: {
+            invoke: {
+              src: "commitStep3",
+              onDone: {
+                target: "step4",
+              },
+              onError: {
+                target: "#transaction.failed",
+              },
+            },
+          },
+          step4: {
+            invoke: {
+              src: "commitStep4",
+              onDone: {
+                target: "#transaction.success",
+              },
+              onError: {
+                target: "#transaction.failed",
+              },
+            },
+          }
+        },
+      },
+      success: {
+        type: "final",
+      },
+      failed: {
+        type: "final",
+      },
+    },
+  },
+  {
+    actors: {
+      commitStep1: fromPromise(async ({ input }) => {
+        // Simulate Step1 async logic
+        console.log("Committing Step 1:", input);
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        return { status: "step1-success" };
+      }),
+      commitStep2: fromPromise(async ({ input }) => {
+        // Simulate Step2 async logic
+        console.log("Committing Step 2:", input);
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        return { status: "step2-success" };
+      }),
+      commitStep3: fromPromise(async ({ input }) => {
+        // Simulate Step3 async logic
+        console.log("Committing Step 3:", input);
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        return { status: "step3-success" };
+      }),
+      commitStep4: fromPromise(async ({ input }) => {
+        // Simulate Step4 async logic
+        console.log("Committing Step 4:", input);
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        return { status: "step4-success" };
+      }),
+    },
+  },
+);
+
+const creditCardChargeWithSync = xstate(
+  "creditCardCharge",
+  creditCardChargeMachine,
+  {
+    watcher: {
+      events: [{ event: "START", until: "result", resultKey: "notifyStatus" }],
+    },
+  },
+) as any;
+
+const transactionWithSync = xstate(
+  "transaction",
+  transactionMachine,
+  {
+    watcher: {
+      events: [{ event: "START", until: "tagCleared", observedTag: "transactionCommit" }], // Event response will be sent when the tag is cleared
+      //   events: [{ event: "START", until: "tagObserved", observedTag: "transactionStep2Commit" }], // Event response will be sent when the tag is observed
+      
+      // You can also use 'final' as the until condition
+      //   until: "final", // Will wait for the machine to reach a final state
+      //   until: "tagObserved" or "tagCleared", // Will wait for the value in observedTag to be observed/cleared
+      //   until: "result", resultKey: "transactionStatus", // Will return the value of this key from the state machine context
+      // You can also define multiple events with different until conditions
+    
+    },
+  },
+) as any;
 
 // Register as a restate xstate service
 await restate.serve({
-  services: [creditCardChargeWithSync, creditCardChargeWithSync.watcher!],
-  port: 9083
+  services: [creditCardChargeWithSync, creditCardChargeWithSync.watcher!, transactionWithSync, transactionWithSync.watcher!],
+  port: 9083,
 });

--- a/packages/examples/src/syncWorkflows/app.ts
+++ b/packages/examples/src/syncWorkflows/app.ts
@@ -209,7 +209,7 @@ const creditCardChargeWithSync = xstate(
   creditCardChargeMachine,
   {
     watcher: {
-      events: [{ event: "START", until: "result", resultKey: "notifyStatus" }],
+      events: [{ event: "START", condition: "result", resultKey: "notifyStatus" }],
     },
   },
 ) as any;
@@ -219,13 +219,13 @@ const transactionWithSync = xstate(
   transactionMachine,
   {
     watcher: {
-      events: [{ event: "START", until: "tagCleared", observedTag: "transactionCommit" }], // Event response will be sent when the tag is cleared
-      //   events: [{ event: "START", until: "tagObserved", observedTag: "transactionStep2Commit" }], // Event response will be sent when the tag is observed
-      
-      // You can also use 'final' as the until condition
-      //   until: "final", // Will wait for the machine to reach a final state
-      //   until: "tagObserved" or "tagCleared", // Will wait for the value in observedTag to be observed/cleared
-      //   until: "result", resultKey: "transactionStatus", // Will return the value of this key from the state machine context
+      events: [{ event: "START", condition: "tagCleared", observeTag: "transactionCommit" }], // Event response will be sent when the tag is cleared
+      //   events: [{ event: "START", condition: "tagObserved", observedTag: "transactionStep2Commit" }], // Event response will be sent when the tag is observed
+
+      // You can also use 'final' as the condition
+      //   condition: "final", // Will wait for the machine to reach a final state
+      //   condition: "tagObserved" or "tagCleared", // Will wait for the value in observedTag to be observed/cleared
+      //   condition: "result", resultKey: "transactionStatus", // Will return the value of this key from the state machine context
       // You can also define multiple events with different until conditions
     
     },

--- a/packages/restate-xstate/src/index.ts
+++ b/packages/restate-xstate/src/index.ts
@@ -16,6 +16,10 @@ export type {
   XStateApi,
   ActorObject,
   ActorObjectHandlers,
+  WatcherDefaults,
+  XStateWatcherApi,
+  WatchEvent,
+  WatchCondition,
 } from "./lib/types.js";
 /**
  * @deprecated Please import from `@restatedev/xstate/promise`

--- a/packages/restate-xstate/src/lib/actorObject.ts
+++ b/packages/restate-xstate/src/lib/actorObject.ts
@@ -448,7 +448,7 @@ export function actorObject<
 
           if (
             !req.condition ||
-            !ValidWatchCondition[req.condition]
+            !Object.values(ValidWatchCondition).includes(req.condition)
           ) {
             throw new restate.TerminalError(
               "Invalid request: 'condition' must be one of ValidWatchCondition values",
@@ -487,7 +487,7 @@ export function actorObject<
             // Get the current state of the machine
             const hasTag = await selfClient.hasTag({ tag });
             const snapshot = await selfClient.snapshot() as any;
-            const isFinal = snapshot.isFinal;
+            const isFinal = snapshot.status === 'done';
             console.log(
               `Live snapshot of state machine ${systemName} at version ${version}: ${JSON.stringify(
                 snapshot,

--- a/packages/restate-xstate/src/lib/actorObject.ts
+++ b/packages/restate-xstate/src/lib/actorObject.ts
@@ -22,6 +22,7 @@ import type {
   WaitForRequest,
   WatchResult,
 } from "./types.js";
+import { ValidWatchCondition } from "./types.js";
 import { resolveReferencedActor } from "./utils.js";
 import { createActor } from "./createActor.js";
 import { createScheduledEventId, type RestateActorSystem } from "./system.js";
@@ -446,34 +447,32 @@ export function actorObject<
           );
 
           if (
-            !req.until ||
-            !["final", "tagObserved", "tagCleared", "result"].includes(
-              req.until,
-            )
+            !req.condition ||
+            !ValidWatchCondition[req.condition]
           ) {
             throw new restate.TerminalError(
-              "Invalid request: 'until' must be one of 'final', 'tagObserved', 'tagCleared', or 'result'",
+              "Invalid request: 'condition' must be one of ValidWatchCondition values",
             );
           }
-          if (req.until === "result" && !req.resultKey) {
+          if (req.condition === "result" && !req.resultKey) {
             throw new restate.TerminalError(
-              "Invalid request: 'resultKey' must be provided when 'until' is 'result'",
+              "Invalid request: 'resultKey' must be provided when 'condition' is 'result'",
             );
           }
           if (
-            (req.until === "tagObserved" || req.until === "tagCleared") &&
-            !req.observedTag
+            (req.condition === "tagObserved" || req.condition === "tagCleared") &&
+            !req.observeTag
           ) {
             throw new restate.TerminalError(
-              "Invalid request: 'tag' must be provided when 'until' is 'tagObserved'",
+              "Invalid request: 'tag' must be provided when 'condition' is 'tagObserved' or 'tagCleared'",
             );
           }
 
-          const until = req.until;
-          const tag = req.observedTag as string;
+          const until = req.condition;
+          const tag = req.observeTag as string;
           const awaitResultKey = req.resultKey;
           const intervalMs = req.intervalMs || 1000;
-          const timeoutMs = req.timeoutMs || 30000;
+          const timeoutMs = req.timeoutMs || 60000;
 
           const selfClient = ctx.objectClient<
             ActorObjectHandlers<AnyStateMachine>

--- a/packages/restate-xstate/src/lib/actorObject.ts
+++ b/packages/restate-xstate/src/lib/actorObject.ts
@@ -66,21 +66,6 @@ async function getVersion<
   return version;
 }
 
-function withNoopSet<S extends restate.TypedState>(
-  ctx: restate.ObjectContext<S> | restate.ObjectSharedContext<S>,
-): restate.ObjectContext<S> {
-  return new Proxy(ctx, {
-    get(target, prop) {
-      if (prop === "set" || prop === "clear" || prop === "clearAll") {
-        return () => {
-          // noop
-        };
-      }
-      return (target as any)[prop];
-    },
-  }) as restate.ObjectContext<S>;
-}
-
 function getLogic<
   LatestStateMachine extends AnyStateMachine,
   PreviousStateMachine extends AnyStateMachine,

--- a/packages/restate-xstate/src/lib/actorWatcherObject.ts
+++ b/packages/restate-xstate/src/lib/actorWatcherObject.ts
@@ -75,7 +75,7 @@ export function actorWatcherObject(
           const resultKey = eventWatchUntils?.resultKey;
           const observeTag = eventWatchUntils?.observeTag;
           const intervalMs =
-            req.intervalMs || watcherDefaults?.intervalMs || 1000;
+            req.intervalMs || watcherDefaults?.intervalMs || 500;
           const timeoutMs =
             req.timeoutMs || watcherDefaults?.timeoutMs || 60000;
 
@@ -97,8 +97,8 @@ export function actorWatcherObject(
 
           
 
-          console.log(
-            `Sending event ${JSON.stringify(req.event)} to machine:${originalMachineName}, with key:${ctx.key}, with request:${req}`,
+          ctx.console.log(
+            `Sending event ${JSON.stringify(req.event)} to machine:${originalMachineName}, with key:${ctx.key}`,
           );
 
           // Send the event to the machine instance
@@ -108,9 +108,6 @@ export function actorWatcherObject(
               source: "actorWatcherObject/sendWithAwait",
             });
           } catch (error) {
-            console.error(
-              `Error sending event to ${originalMachineName} machine: ${error}`,
-            );
             throw new restate.TerminalError(
               `Error sending event to machine ${originalMachineName}: ${error}`,
             );
@@ -119,14 +116,11 @@ export function actorWatcherObject(
           
 
           // Sleep for the initial interval for send event to materialize
-          console.log(
+          ctx.console.log(
             `Sleeping for ${intervalMs}ms to allow event to materialize in machine: ${originalMachineName}, with key: ${ctx.key}`,
           );
           await ctx.sleep(intervalMs);
 
-          console.log(
-            `Waiting for response from machine:${originalMachineName}, with key:${ctx.key}`,
-          );
           let result: WatchResult = (await (machineClient as any).waitFor({
             condition,
             observeTag,
@@ -135,8 +129,8 @@ export function actorWatcherObject(
             timeoutMs,
           })) as WatchResult;
 
-          console.log(
-            `Received response from machine: ${originalMachineName}, with key:${ctx.key}. Result: ${JSON.stringify(result)}`,
+          ctx.console.log(
+            `Received response from machine: ${originalMachineName}, with key:${ctx.key}}`,
           );
           result.waitedMs = Date.now() - startTime;
           return result;

--- a/packages/restate-xstate/src/lib/actorWatcherObject.ts
+++ b/packages/restate-xstate/src/lib/actorWatcherObject.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * This object will provide a side car handlers (sendWithAwait) to state machines represented in actorObject.
+ * These handlers will be used to send events to the state machine, on behalf of the clients that await for the response to the events.
+ */
+
+import * as restate from "@restatedev/restate-sdk";
+import type {
+  WatchableXStateApi,
+  WatcherDefaults,
+  WatchRequest,
+  WatchResult,
+} from "./types.js";
+
+export function actorWatcherObject(
+  watcherName: string,
+  watcherDefaults?: WatcherDefaults,
+) {
+  return restate.object({
+    name: watcherName,
+    handlers: {
+      sendWithAwait: restate.handlers.object.exclusive(
+        async (
+          ctx: restate.ObjectContext<any>,
+          req: WatchRequest,
+        ): Promise<WatchResult> => {
+          if (
+            !req.objectName ||
+            !req.event ||
+            !req.objectId ||
+            typeof req.event !== "object"
+          ) {
+            throw new restate.TerminalError(
+              "Invalid request: objectName, event, and objectId are required",
+            );
+          }
+
+          const tag = req.tag || watcherDefaults?.defaultTag || "sync";
+          const intervalMs =
+            req.intervalMs || watcherDefaults?.defaultIntervalMs || 1000;
+          const timeoutMs =
+            req.timeoutMs || watcherDefaults?.defaultTimeoutMs || 60000;
+
+          // Send event to the machine object
+          const machineClient = ctx.objectClient<WatchableXStateApi>(
+            { name: req.objectName },
+            req.objectId,
+          );
+
+          // Send the event to the machine instance
+          (machineClient as any).send({
+            event: req.event,
+            source: "actorWatcherObject/sendWithAwait",
+          });
+          // Wait for the response
+          await ctx.sleep(intervalMs);
+
+          // Start the timer to observe transitions
+          const startTime = Date.now();
+
+          let result: WatchResult = {
+            timedOut: false,
+            waitedMs: Date.now() - startTime,
+          };
+
+          while (true) {
+            let checkTagResult;
+            try {
+              checkTagResult = await (machineClient as any).checkTag({ tag });
+            } catch (error) {
+              console.error(`Error checking tag: ${error}`);
+              await ctx.sleep(intervalMs);
+            }
+
+            if (
+              !checkTagResult ||
+              typeof checkTagResult !== "object" ||
+              !("isFinal" in checkTagResult) ||
+              !("hasTag" in checkTagResult) ||
+              !("snapshot" in checkTagResult)
+            ) {
+              console.error(
+                `Invalid response from checkTag object could be still materializing: ${checkTagResult}. Retrying...`,
+              );
+              await ctx.sleep(intervalMs);
+            }
+            // Check if the state is final or tag has fallen off
+            if (
+              checkTagResult &&
+              (checkTagResult.isFinal || !checkTagResult.hasTag)
+            ) {
+              return {
+                timedOut: false,
+                waitedMs: Date.now() - startTime,
+                result: checkTagResult.snapshot,
+              };
+            }
+            // Check if the timeout has been reached
+            if (Date.now() - startTime >= timeoutMs) {
+              return {
+                timedOut: true,
+                waitedMs: Date.now() - startTime,
+                error: new Error(
+                  `Timeout after ${timeoutMs}ms waiting for tag "${tag}" on object "${req.objectName}" with ID "${req.objectId}"`,
+                ),
+              };
+            }
+            await ctx.sleep(intervalMs);
+          }
+        },
+      ),
+    },
+  });
+}

--- a/packages/restate-xstate/src/lib/types.ts
+++ b/packages/restate-xstate/src/lib/types.ts
@@ -138,19 +138,20 @@ export type WatchableXStateApi = Pick<
   "send" | "snapshot" | "hasTag"
 >;
 
-export type WatchUntil = "final" | "tagObserved" | "tagCleared" | "result";
+export type WatchCondition = "final" | "tagObserved" | "tagCleared" | "result";
+export enum ValidWatchCondition {
+  "final",
+  "tagObserved",
+  "tagCleared",
+  "result"
+}
 export type WatchEvent = {
   event: string;
-  until?: WatchUntil;
-  observedTag?: string;
+  condition?: WatchCondition;
+  observeTag?: string;
   resultKey?: string;
 };
 
-export type WatchEventUntils = {
-  until?: WatchUntil;
-  observedTag?: string;
-  resultKey?: string;
-};
 export type WatcherDefaults = {
   events?: WatchEvent[];
   intervalMs?: number;
@@ -168,7 +169,10 @@ export type WatchRequest = {
   timeoutMs?: number;
 };
 
-export type WaitForRequest = WatchEventUntils & {
+export type WaitForRequest = {
+  condition: WatchCondition;
+  observeTag?: string;
+  resultKey?: string;
   intervalMs?: number;
   timeoutMs?: number;
 };

--- a/packages/restate-xstate/src/lib/types.ts
+++ b/packages/restate-xstate/src/lib/types.ts
@@ -164,7 +164,7 @@ export type WatchRequest = {
   event: {
     type: string;
   };
-  until?: WatchEvent[];
+  until?: WatchEvent;
   intervalMs?: number;
   timeoutMs?: number;
 };

--- a/packages/restate-xstate/src/lib/types.ts
+++ b/packages/restate-xstate/src/lib/types.ts
@@ -64,6 +64,7 @@ export interface XStateOptions<PreviousStateMachine extends AnyStateMachine> {
    * @default Infinity
    * */
   finalStateTTL?: number;
+  watcher?: WatcherDefaults;
 }
 
 export type ActorObjectHandlers<LatestStateMachine extends AnyStateMachine> = {
@@ -110,6 +111,13 @@ export type XStateApi<
   P extends string,
   LatestStateMachine extends AnyStateMachine,
 > = ReturnType<ActorObject<P, LatestStateMachine, AnyStateMachine>>;
+
+export type XStateWatcherApi<
+  P extends string,
+  LatestStateMachine extends AnyStateMachine,
+> = XStateApi<P, LatestStateMachine> & {
+  watcher: VirtualObjectDefinition<string, any>;
+};
 
 export type NoContextActorObjectHandlers<ActorObjectHandler> = {
   [Key in keyof ActorObjectHandler]: 

--- a/packages/restate-xstate/src/lib/xstate.ts
+++ b/packages/restate-xstate/src/lib/xstate.ts
@@ -1,5 +1,5 @@
 import type { AnyStateMachine } from "xstate";
-import type { XStateApi, XStateOptions, XStateWatcherApi, WatchUntil } from "./types.js";
+import type { XStateApi, XStateOptions, XStateWatcherApi } from "./types.js";
 import { actorObject } from "./actorObject.js";
 import { actorWatcherObject } from "./actorWatcherObject.js";
 

--- a/packages/restate-xstate/src/lib/xstate.ts
+++ b/packages/restate-xstate/src/lib/xstate.ts
@@ -1,5 +1,5 @@
 import type { AnyStateMachine } from "xstate";
-import type { XStateApi, XStateOptions, XStateWatcherApi } from "./types.js";
+import type { XStateApi, XStateOptions, XStateWatcherApi, WatchUntil } from "./types.js";
 import { actorObject } from "./actorObject.js";
 import { actorWatcherObject } from "./actorWatcherObject.js";
 
@@ -29,7 +29,7 @@ export const xstate = <
 
   const originalActor = actorObject(path, logic, options);
 
-  if (options?.watcher && options?.watcher.defaultTag !== '') {
+  if (options?.watcher && options?.watcher.events != undefined) {
     const finalActor = originalActor as XStateWatcherApi<P, LatestStateMachine>;
     // Note: '/' is not allowed in object names
     // Create a corresponding watcher object for the original actor

--- a/packages/tests/src/lib/workflowWithSyncSupport.test.ts
+++ b/packages/tests/src/lib/workflowWithSyncSupport.test.ts
@@ -1,0 +1,163 @@
+import { xstate } from "@restatedev/xstate";
+import { describe, it } from "vitest";
+import { createRestateTestActor } from "@restatedev/xstate-test";
+import { fromPromise } from "@restatedev/xstate/promise";
+import { setup, assign, type SnapshotFrom } from "xstate";
+import { eventually } from "./eventually.js";
+import { error } from "console";
+
+const workflow = setup({
+  actors: {
+    commitStep1: fromPromise(async ({ input }) => {
+      // Simulate Step1 async logic
+      console.log("Committing Step 1:", input);
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      return { status: "step1-success" };
+    }),
+    commitStep2: fromPromise(async ({ input }) => {
+      // Simulate Step2 async logic
+      console.log("Committing Step 2:", input);
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      return { status: "step2-success" };
+    }),
+    commitStep3: fromPromise(async ({ input }) => {
+      // Simulate Step3 async logic
+      console.log("Committing Step 3:", input);
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      return { status: "step3-success" };
+    }),
+    commitStep4: fromPromise(async ({ input }) => {
+      // Simulate Step4 async logic
+      console.log("Committing Step 4:", input);
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      return { status: "step4-success" };
+    }),
+    recordTransaction: fromPromise(async ({ input }) => {
+      // Simulate recording transaction logic
+      console.log("Recording transaction:", input);
+      await new Promise((resolve) => setTimeout(resolve, 4000));
+      return { status: "transaction-recorded" };
+    }),
+  },
+}).createMachine({
+  id: "transaction",
+  context: {
+    error: null as string | null,
+    transactionStatus: undefined,
+    senderUserID: "",
+    recipientUserID: "",
+    amount: 0,
+  },
+  states: {
+    idle: {
+      on: {
+        START: {
+          target: "commitTransaction",
+        },
+      },
+    },
+    commitTransaction: {
+      tags: ["transactionCommit"],
+      initial: "step1",
+      states: {
+        step1: {
+          invoke: {
+            src: "commitStep1",
+            onDone: {
+              target: "step2",
+            },
+            onError: {
+              target: "#transaction.failed",
+            },
+          },
+        },
+        step2: {
+          tags: ["transactionStep2Commit"],
+          invoke: {
+            src: "commitStep2",
+            onDone: {
+              target: "step3",
+            },
+            onError: {
+              target: "#transaction.failed",
+            },
+          },
+        },
+        step3: {
+          invoke: {
+            src: "commitStep3",
+            onDone: {
+              target: "step4",
+            },
+            onError: {
+              target: "#transaction.failed",
+            },
+          },
+        },
+        step4: {
+          invoke: {
+            src: "commitStep4",
+            onDone: {
+              target: "#transaction.recordTransaction",
+            },
+            onError: {
+              target: "#transaction.failed",
+            },
+          },
+        },
+      },
+    },
+    recordTransaction: {
+      invoke: {
+        src: "recordTransaction",
+        onDone: {
+          target: "success",
+          actions: assign({
+            transactionStatus: ({ event }) => event.output.status,
+          }),
+        },
+        onError: {
+          target: "failed",
+        },
+      },
+    },
+    success: {
+      type: "final",
+    },
+    failed: {
+      type: "final",
+    },
+  },
+});
+
+describe("An event based workflow with sync support", () => {
+  it("Will complete successfully", { timeout: 20_000 }, async () => {
+    const wf = xstate("workflow", workflow);
+
+    using actor = await createRestateTestActor<SnapshotFrom<typeof workflow>>({
+      machine: wf,
+      input: {
+        senderUserID: "user1",
+        recipientUserID: "user2",
+        amount: 100,
+      },
+    });
+
+    await actor.send({
+      type: "START",
+    });
+
+    await eventually(() => actor.snapshot()).toMatchObject({
+          status: "done",
+          value: "success",
+          context: {
+            error: null,
+            senderUserID: "user1",
+            recipientUserID: "user2",
+            amount: 100,
+            transactionStatus: "transaction-recorded",
+          }
+    });
+
+  });
+});


### PR DESCRIPTION
Provide synchronous support to clients interacting with back end state machines. actorWatcherObject provides a non-blocking way to wait for response from the original state machine, by tracking it's state/tags/context.