### PR TITLE
Fix `after` delayed transitions firing immediately on restate-sdk >=1.12.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ packages/*/buf.lock
 
 restate-data
 .DS_Store
+
+# Claude
+.claude/

--- a/packages/restate-xstate/README.md
+++ b/packages/restate-xstate/README.md
@@ -20,6 +20,13 @@ that uses cross-machine communication, delays, and Promise actors, all running i
 Most XState machines should work out of the box, but this is still experimental, so
 we haven't tested everything yet!
 
+## Compatibility
+
+`@restatedev/xstate@0.5.2`+ requires `@restatedev/restate-sdk` **>= 1.3.0**. If you
+are pinning a more recent SDK, you must upgrade to 0.5.2: with 0.5.0 / 0.5.1 paired
+against SDKs >= 1.12.0, XState `after` delayed transitions fire immediately instead
+of waiting for the configured delay.
+
 To try out this example:
 
 ```bash

--- a/packages/restate-xstate/src/lib/system.ts
+++ b/packages/restate-xstate/src/lib/system.ts
@@ -113,10 +113,11 @@ export async function createSystem<T extends ActorSystemInfo>(
 
       events[scheduledEventId] = scheduledEvent;
       ctx
-        .objectSendClient<
-          ActorObjectHandlers<AnyStateMachine>
-        >(api, systemName, { delay })
-        .send({ scheduledEvent, source, target, event });
+        .objectSendClient<ActorObjectHandlers<AnyStateMachine>>(api, systemName)
+        .send(
+          { scheduledEvent, source, target, event },
+          restate.SendOpts.from({ delay }),
+        );
 
       ctx.set("events", events);
     },

--- a/packages/tests/src/lib/cleanup.test.ts
+++ b/packages/tests/src/lib/cleanup.test.ts
@@ -11,7 +11,7 @@
 
 import { xstate } from "@restatedev/xstate";
 import { createMachine } from "xstate";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createRestateTestActor } from "@restatedev/xstate-test";
 import { wait } from "./eventually.js";
 
@@ -89,9 +89,12 @@ describe("Cleanup", () => {
         status: "done",
         value: "done",
       });
-      await wait(100);
-      await expect(() => machine.snapshot()).rejects.toThrow(
-        "The state machine has been disposed after reaching it's final state",
+      await vi.waitFor(
+        () =>
+          expect(() => machine.snapshot()).rejects.toThrow(
+            "The state machine has been disposed after reaching it's final state",
+          ),
+        { timeout: 5_000 },
       );
 
       /** Should not accept any events after termination */
@@ -128,9 +131,12 @@ describe("Cleanup", () => {
         value: "done",
       });
 
-      await wait(100);
-      await expect(() => machine.snapshot()).rejects.toThrow(
-        "The state machine has been disposed after reaching it's final state",
+      await vi.waitFor(
+        () =>
+          expect(() => machine.snapshot()).rejects.toThrow(
+            "The state machine has been disposed after reaching it's final state",
+          ),
+        { timeout: 5_000 },
       );
     },
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,14 +7,14 @@ settings:
 catalogs:
   default:
     '@restatedev/restate-sdk':
-      specifier: ^1.9.0
-      version: 1.9.1
+      specifier: ^1.14.0
+      version: 1.14.3
     '@restatedev/restate-sdk-clients':
-      specifier: ^1.9.0
-      version: 1.9.1
+      specifier: ^1.14.0
+      version: 1.14.3
     '@restatedev/restate-sdk-testcontainers':
-      specifier: ^1.9.0
-      version: 1.9.1
+      specifier: ^1.14.0
+      version: 1.14.3
     xstate:
       specifier: ^5.20.1
       version: 5.20.1
@@ -95,7 +95,7 @@ importers:
     dependencies:
       '@restatedev/restate-sdk':
         specifier: 'catalog:'
-        version: 1.9.1
+        version: 1.14.3
       '@restatedev/xstate':
         specifier: workspace:*
         version: link:../restate-xstate
@@ -105,35 +105,35 @@ importers:
     devDependencies:
       '@restatedev/restate-sdk-testcontainers':
         specifier: 'catalog:'
-        version: 1.9.1
+        version: 1.14.3
 
   packages/restate-xstate:
     dependencies:
       '@restatedev/restate-sdk':
         specifier: 'catalog:'
-        version: 1.9.1
+        version: 1.14.3
       xstate:
         specifier: 'catalog:'
         version: 5.20.1
     devDependencies:
       '@restatedev/restate-sdk-clients':
         specifier: 'catalog:'
-        version: 1.9.1
+        version: 1.14.3
       '@restatedev/restate-sdk-testcontainers':
         specifier: 'catalog:'
-        version: 1.9.1
+        version: 1.14.3
 
   packages/restate-xstate-test:
     dependencies:
       '@restatedev/restate-sdk':
         specifier: 'catalog:'
-        version: 1.9.1
+        version: 1.14.3
       '@restatedev/restate-sdk-clients':
         specifier: 'catalog:'
-        version: 1.9.1
+        version: 1.14.3
       '@restatedev/restate-sdk-testcontainers':
         specifier: 'catalog:'
-        version: 1.9.1
+        version: 1.14.3
       '@restatedev/xstate':
         specifier: workspace:^
         version: link:../restate-xstate
@@ -145,13 +145,13 @@ importers:
     dependencies:
       '@restatedev/restate-sdk':
         specifier: 'catalog:'
-        version: 1.9.1
+        version: 1.14.3
       '@restatedev/restate-sdk-clients':
         specifier: 'catalog:'
-        version: 1.9.1
+        version: 1.14.3
       '@restatedev/restate-sdk-testcontainers':
         specifier: 'catalog:'
-        version: 1.9.1
+        version: 1.14.3
       '@restatedev/xstate':
         specifier: workspace:*
         version: link:../restate-xstate
@@ -489,10 +489,6 @@ packages:
     resolution: {integrity: sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
-
   '@grpc/grpc-js@1.13.4':
     resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
     engines: {node: '>=12.10.0'}
@@ -545,6 +541,9 @@ packages:
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
   '@loaderkit/resolve@1.0.4':
     resolution: {integrity: sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A==}
@@ -628,21 +627,17 @@ packages:
     resolution: {integrity: sha512-G0OnZbMWEs5LhDyqy2UL17vGhSVHkQIfVojMtEWVenvj0V5S84VBgy86kJIuNsGDp2p7sTKlpSIpBUWdC35OKg==}
     engines: {node: '>=20.0.0'}
 
-  '@restatedev/restate-sdk-clients@1.9.1':
-    resolution: {integrity: sha512-dOZVBDVvjK8SwgTPwMM5UYYXTU+8BHk4D9QTtDUYca/lOgVAIHoQEPy5e50UJ+/cCo6NouD9lmIC+6qKbN3dsA==}
-    engines: {node: '>= 20.19'}
+  '@restatedev/restate-sdk-clients@1.14.3':
+    resolution: {integrity: sha512-6g81nP2vkHUko6DOtvTeFQhouMYdUhgqtyEu2hOR4WgmF5WZdikCpD8Ysj7umKkdy/6X83pqW0hW1O9CWf3OHQ==}
 
-  '@restatedev/restate-sdk-core@1.9.1':
-    resolution: {integrity: sha512-/ISSWBF0YAH0mhIhnd6VFuFLMp6AckdfGyfU+CdJDccysxH1qp0QuI5oJ5UArexoFTI6LXrWkYg2/nZebO96gA==}
-    engines: {node: '>= 20.19'}
+  '@restatedev/restate-sdk-core@1.14.3':
+    resolution: {integrity: sha512-EHyErOWtH13wrsAGNzMt1PMWtenTfji4Oc8K1KktY6m23iQ4laCgEeS67xk8aZEDIvKLiInRPX6zQfTONoDq5w==}
 
-  '@restatedev/restate-sdk-testcontainers@1.9.1':
-    resolution: {integrity: sha512-10UcOQKBVcyyzb4j0yLKoxR6xtR/xRVCKQ4t+silQAgzV/IhgPhbzDhEpo4nbyNpMtOXiD2121RmLGeKM1lW7g==}
-    engines: {node: '>= 20.19'}
+  '@restatedev/restate-sdk-testcontainers@1.14.3':
+    resolution: {integrity: sha512-Bs/O80UbEeOj5ilRuOmBM8hbk3T/bvqDy2ZWclGnmyEs+WIsLeYbhz6YckYlW+HRAgy9xU0T7hB6cuL45CvMLg==}
 
-  '@restatedev/restate-sdk@1.9.1':
-    resolution: {integrity: sha512-8w6t7cG5mXMgI+YPxIuPuplVX12lKbgne1byzmkQtif9lpPT6gjd7ce1EmWrUtsD25WCL+lf4iKU/usfqaXQCg==}
-    engines: {node: '>= 20.19'}
+  '@restatedev/restate-sdk@1.14.3':
+    resolution: {integrity: sha512-UvoY1p3hbCKMqiHZrFo1Ju4bRbV6hO4uC9q+H9i1r8lheXYlVKK55NIguSLjyxCx8wczVAy9m0syL1afUqGGVA==}
 
   '@rolldown/binding-android-arm64@1.0.0-beta.29':
     resolution: {integrity: sha512-pDv7gg59Gdy80eFmMkEqXEaoJi3Y9W/a9T3z9M4t8Ma8aVXNldvSy9UgtlX7AK7DPqF8tULnmIZ2Z3rvGMz/NQ==}
@@ -870,8 +865,8 @@ packages:
   '@types/docker-modem@3.0.6':
     resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
 
-  '@types/dockerode@3.3.42':
-    resolution: {integrity: sha512-U1jqHMShibMEWHdxYhj3rCMNCiLx5f35i4e3CEUuW+JSSszc/tVqc6WCAPdhwBymG5R/vgbcceagK0St7Cq6Eg==}
+  '@types/dockerode@4.0.1':
+    resolution: {integrity: sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1167,6 +1162,9 @@ packages:
   birpc@2.5.0:
     resolution: {integrity: sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ==}
 
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -1180,6 +1178,9 @@ packages:
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -1236,6 +1237,9 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -1319,6 +1323,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
 
@@ -1351,16 +1364,16 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
-  docker-compose@0.24.8:
-    resolution: {integrity: sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==}
+  docker-compose@1.4.2:
+    resolution: {integrity: sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==}
     engines: {node: '>= 6.0.0'}
 
-  docker-modem@5.0.6:
-    resolution: {integrity: sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==}
+  docker-modem@5.0.7:
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
     engines: {node: '>= 8.0'}
 
-  dockerode@4.0.7:
-    resolution: {integrity: sha512-R+rgrSRTRdU5mH14PZTCPZtW/zw3HDWNTS/1ZAQpL/5Upe/ye5K9WQkIysu4wBoiMwKynsz0a8qWuGsHgEvSAA==}
+  dockerode@4.0.12:
+    resolution: {integrity: sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==}
     engines: {node: '>= 8.0'}
 
   dts-resolver@2.1.1:
@@ -1583,6 +1596,9 @@ packages:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@11.3.0:
     resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
     engines: {node: '>=14.14'}
@@ -1607,8 +1623,8 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-port@7.1.0:
-    resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
+  get-port@7.2.0:
+    resolution: {integrity: sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==}
     engines: {node: '>=16'}
 
   get-tsconfig@4.10.1:
@@ -1627,6 +1643,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@14.0.0:
@@ -2002,8 +2019,11 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2172,9 +2192,9 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
-  properties-reader@2.3.0:
-    resolution: {integrity: sha512-z597WicA7nDZxK12kZqHr2TcvwNU1GCfA5UwfDY/HDp3hXPoPlb5rlEx9bwGTiJnc0OqbBTkU975jDToth8Gxw==}
-    engines: {node: '>=14'}
+  properties-reader@3.0.1:
+    resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
+    engines: {node: '>=18'}
 
   protobufjs@7.5.3:
     resolution: {integrity: sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==}
@@ -2419,8 +2439,15 @@ packages:
     resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
     engines: {node: '>=12.17'}
 
-  tar-fs@3.1.1:
-    resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
@@ -2429,8 +2456,8 @@ packages:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
 
-  testcontainers@10.28.0:
-    resolution: {integrity: sha512-1fKrRRCsgAQNkarjHCMKzBKXSJFmzNTiTbhb5E/j5hflRXChEtHvkefjaHlgkNUjfw92/Dq8LTgwQn6RDBFbMg==}
+  testcontainers@11.14.0:
+    resolution: {integrity: sha512-r9pniwv/iwzyHaI7gwAvAm4Y+IvjJg3vBWdjrUCaDMc2AXIr4jKbq7jJO18Mw2ybs73pZy1Aj7p/4RVBGMRWjg==}
 
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
@@ -2564,9 +2591,9 @@ packages:
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
@@ -2600,6 +2627,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-name@5.0.1:
@@ -3121,8 +3149,6 @@ snapshots:
       '@eslint/core': 0.15.1
       levn: 0.4.1
 
-  '@fastify/busboy@2.1.1': {}
-
   '@grpc/grpc-js@1.13.4':
     dependencies:
       '@grpc/proto-loader': 0.7.15
@@ -3174,6 +3200,12 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.4
 
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@loaderkit/resolve@1.0.4':
     dependencies:
@@ -3283,25 +3315,25 @@ snapshots:
     dependencies:
       quansync: 0.2.10
 
-  '@restatedev/restate-sdk-clients@1.9.1':
+  '@restatedev/restate-sdk-clients@1.14.3':
     dependencies:
-      '@restatedev/restate-sdk-core': 1.9.1
+      '@restatedev/restate-sdk-core': 1.14.3
 
-  '@restatedev/restate-sdk-core@1.9.1': {}
+  '@restatedev/restate-sdk-core@1.14.3': {}
 
-  '@restatedev/restate-sdk-testcontainers@1.9.1':
+  '@restatedev/restate-sdk-testcontainers@1.14.3':
     dependencies:
-      '@restatedev/restate-sdk': 1.9.1
-      '@restatedev/restate-sdk-clients': 1.9.1
+      '@restatedev/restate-sdk': 1.14.3
+      '@restatedev/restate-sdk-clients': 1.14.3
       apache-arrow: 18.1.0
-      testcontainers: 10.28.0
+      testcontainers: 11.14.0
     transitivePeerDependencies:
       - bare-buffer
       - supports-color
 
-  '@restatedev/restate-sdk@1.9.1':
+  '@restatedev/restate-sdk@1.14.3':
     dependencies:
-      '@restatedev/restate-sdk-core': 1.9.1
+      '@restatedev/restate-sdk-core': 1.14.3
 
   '@rolldown/binding-android-arm64@1.0.0-beta.29':
     optional: true
@@ -3475,7 +3507,7 @@ snapshots:
       '@types/node': 24.0.15
       '@types/ssh2': 1.15.5
 
-  '@types/dockerode@3.3.42':
+  '@types/dockerode@4.0.1':
     dependencies:
       '@types/docker-modem': 3.0.6
       '@types/node': 24.0.15
@@ -3816,6 +3848,12 @@ snapshots:
 
   birpc@2.5.0: {}
 
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -3830,6 +3868,11 @@ snapshots:
       fill-range: 7.1.1
 
   buffer-crc32@1.0.0: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   buffer@6.0.3:
     dependencies:
@@ -3877,6 +3920,8 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  chownr@1.1.4: {}
 
   ci-info@3.9.0: {}
 
@@ -3968,6 +4013,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decode-named-character-reference@1.2.0:
     dependencies:
       character-entities: 2.0.2
@@ -3992,30 +4041,29 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  docker-compose@0.24.8:
+  docker-compose@1.4.2:
     dependencies:
       yaml: 2.8.0
 
-  docker-modem@5.0.6:
+  docker-modem@5.0.7:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       readable-stream: 3.6.2
       split-ca: 1.0.1
       ssh2: 1.16.0
     transitivePeerDependencies:
       - supports-color
 
-  dockerode@4.0.7:
+  dockerode@4.0.12:
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@grpc/grpc-js': 1.13.4
       '@grpc/proto-loader': 0.7.15
-      docker-modem: 5.0.6
+      docker-modem: 5.0.7
       protobufjs: 7.5.3
-      tar-fs: 3.1.1
+      tar-fs: 2.1.4
       uuid: 10.0.0
     transitivePeerDependencies:
-      - bare-buffer
       - supports-color
 
   dts-resolver@2.1.1: {}
@@ -4261,6 +4309,8 @@ snapshots:
 
   format@0.2.2: {}
 
+  fs-constants@1.0.0: {}
+
   fs-extra@11.3.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -4286,7 +4336,7 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-port@7.1.0: {}
+  get-port@7.2.0: {}
 
   get-tsconfig@4.10.1:
     dependencies:
@@ -4830,7 +4880,9 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  mkdirp@1.0.4: {}
+  mkdirp-classic@0.5.3: {}
+
+  mkdirp@3.0.1: {}
 
   mri@1.2.0: {}
 
@@ -4970,9 +5022,12 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  properties-reader@2.3.0:
+  properties-reader@3.0.1:
     dependencies:
-      mkdirp: 1.0.4
+      '@kwsites/file-exists': 1.1.1
+      mkdirp: 3.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   protobufjs@7.5.3:
     dependencies:
@@ -5260,7 +5315,14 @@ snapshots:
       array-back: 6.2.2
       wordwrapjs: 5.1.0
 
-  tar-fs@3.1.1:
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
+  tar-fs@3.1.2:
     dependencies:
       pump: 3.0.3
       tar-stream: 3.1.7
@@ -5270,6 +5332,14 @@ snapshots:
     transitivePeerDependencies:
       - bare-buffer
 
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   tar-stream@3.1.7:
     dependencies:
       b4a: 1.6.7
@@ -5278,23 +5348,23 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  testcontainers@10.28.0:
+  testcontainers@11.14.0:
     dependencies:
       '@balena/dockerignore': 1.0.2
-      '@types/dockerode': 3.3.42
+      '@types/dockerode': 4.0.1
       archiver: 7.0.1
       async-lock: 1.4.1
       byline: 5.0.0
-      debug: 4.4.1
-      docker-compose: 0.24.8
-      dockerode: 4.0.7
-      get-port: 7.1.0
+      debug: 4.4.3
+      docker-compose: 1.4.2
+      dockerode: 4.0.12
+      get-port: 7.2.0
       proper-lockfile: 4.1.2
-      properties-reader: 2.3.0
+      properties-reader: 3.0.1
       ssh-remote-port-forward: 1.0.4
-      tar-fs: 3.1.1
+      tar-fs: 3.1.2
       tmp: 0.2.5
-      undici: 5.29.0
+      undici: 7.25.0
     transitivePeerDependencies:
       - bare-buffer
       - supports-color
@@ -5416,9 +5486,7 @@ snapshots:
 
   undici-types@7.8.0: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
+  undici@7.25.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,9 +2,9 @@ packages:
   - packages/*
 
 catalog:
-  "@restatedev/restate-sdk": ^1.9.0
-  "@restatedev/restate-sdk-clients": ^1.9.0
-  "@restatedev/restate-sdk-testcontainers": ^1.9.0
+  "@restatedev/restate-sdk": ^1.14.0
+  "@restatedev/restate-sdk-clients": ^1.14.0
+  "@restatedev/restate-sdk-testcontainers": ^1.14.0
   xstate: ^5.20.1
 
 onlyBuiltDependencies:


### PR DESCRIPTION
The scheduler in system.ts passed `delay` via the legacy third-arg `objectSendClient(api, key, { delay }).send(...)` form. restate-sdk 1.12.0 removed that opts parameter (PR #668), so the delay is silently dropped and the scheduled event fires immediately. Switch to `SendOpts.from({ delay })` as the method-level opts (same pattern as cleanupState..ts).

Bump the dev/test catalog to ^1.14.0 so the existing scheduledEvents test exercises an affected SDK, and stabilise cleanup.test.ts on the new SDK by polling with vi.waitFor instead of a fixed 100ms wait.